### PR TITLE
vmtests: export CURTIN_VMTEST_TAR_DISKS=1 everywhere

### DIFF
--- a/curtin/jobs-vmtest-daily.yaml
+++ b/curtin/jobs-vmtest-daily.yaml
@@ -89,6 +89,7 @@
           export apt_proxy=http://squid.internal:3128
           export TMPDIR=/var/lib/jenkins/tmp/
           export CURTIN_VMTEST_CURTIN_EXE="curtin-from-container $LXC_NAME curtin"
+          export CURTIN_VMTEST_TAR_DISKS=1
 
           rm -Rf curtin-* output
           lxc delete "$LXC_NAME" --force

--- a/curtin/jobs-vmtest-proposed.yaml
+++ b/curtin/jobs-vmtest-proposed.yaml
@@ -39,6 +39,7 @@
           export apt_proxy=http://squid.internal:3128
           export TMPDIR=/var/lib/jenkins/tmp/
           export CURTIN_VMTEST_CURTIN_EXE="curtin-from-container $LXC_NAME curtin"
+          export CURTIN_VMTEST_TAR_DISKS=1
 
           rm -Rf curtin-* output
           pull-lp-source curtin "$RELEASE"-proposed

--- a/curtin/jobs-vmtest.yaml
+++ b/curtin/jobs-vmtest.yaml
@@ -115,6 +115,7 @@
             if [ "$(hostname)" == "torkoal" ]; then
                 export TMPDIR=/var/lib/jenkins/tmp/
             fi
+            export CURTIN_VMTEST_TAR_DISKS=1
 
             rm -Rf curtin-*
             rm -Rf output


### PR DESCRIPTION
Curtin will tar up vmtests disk images to help prevent jenkins master
from exploding sparse disk images into huge multi-gig files by replacing
them with a tarball which retains the sparseness of the images.