### PR TITLE
fix trigger jobs to correctly get and run run version_lookup.py

### DIFF
--- a/cloud-init/integration-proposed.yaml
+++ b/cloud-init/integration-proposed.yaml
@@ -24,8 +24,9 @@
       - shell: |
           #!/bin/bash -ux
 
-          sudo rm version_lookup.py
-          https://raw.githubusercontent.com/canonical-server/test-scripts/master/launchpad/version_lookup.py
+          set -e
+          sudo rm -f version_lookup.py
+          wget https://raw.githubusercontent.com/canonical-server/test-scripts/master/launchpad/version_lookup.py
           chmod +x version_lookup.py
           proposed=$(./version_lookup.py -r xenial -p Proposed -s Published cloud-init)
 
@@ -60,8 +61,9 @@
       - shell: |
           #!/bin/bash -ux
 
-          sudo rm version_lookup.py
-          https://raw.githubusercontent.com/canonical-server/test-scripts/master/launchpad/version_lookup.py
+          set -e
+          sudo rm -f version_lookup.py
+          wget https://raw.githubusercontent.com/canonical-server/test-scripts/master/launchpad/version_lookup.py
           chmod +x version_lookup.py
           proposed=$(./version_lookup.py -r zesty -p Proposed -s Published cloud-init)
 

--- a/curtin/jobs-vmtest-proposed.yaml
+++ b/curtin/jobs-vmtest-proposed.yaml
@@ -80,8 +80,9 @@
       - shell: |
           #!/bin/bash -ux
 
-          sudo rm version_lookup.py
-          https://raw.githubusercontent.com/canonical-server/test-scripts/master/launchpad/version_lookup.py
+          set -e
+          sudo rm -f version_lookup.py
+          wget https://raw.githubusercontent.com/canonical-server/test-scripts/master/launchpad/version_lookup.py
           chmod +x version_lookup.py
           proposed=$(./version_lookup.py -r xenial -p Proposed -s Published curtin)
 
@@ -153,8 +154,9 @@
       - shell: |
           #!/bin/bash -ux
 
-          sudo rm version_lookup.py
-          https://raw.githubusercontent.com/canonical-server/test-scripts/master/launchpad/version_lookup.py
+          set -e
+          sudo rm -f version_lookup.py
+          wget https://raw.githubusercontent.com/canonical-server/test-scripts/master/launchpad/version_lookup.py
           chmod +x version_lookup.py
           proposed=$(./version_lookup.py -r zesty -p Proposed -s Published curtin)
 


### PR DESCRIPTION
The trigger jobs were not working correctly.
The version_lookup was not actually downloaded..

The change here is to:
 a.) download the file
 b.) run with 'set -e' so we fail on failure.