### PR TITLE
do not trigger proposed run if proposed package is in updates.

### DIFF
--- a/cloud-init/integration-proposed.yaml
+++ b/cloud-init/integration-proposed.yaml
@@ -107,16 +107,28 @@
     name: trigger-proposed-integration
     builders:
       - shell: |
-          set -e
-          release={release}
-          triggerwhat={triggerwhat}
+          set -ef
+          rel={release}
+          triggerwhat="{triggerwhat}"
           sudo rm -f version_lookup.py
           wget https://raw.githubusercontent.com/canonical-server/test-scripts/master/launchpad/version_lookup.py
           chmod +x version_lookup.py
-          proposed=$(./version_lookup.py -r $release -p Proposed -s Published cloud-init)
+          pkg="cloud-init"
 
-          if [ "$proposed" != "" ]; then
-            curl -X POST --netrc-file $JENKINS_HOME/jenkins-bot-creds http://server-team-jenkins-be.internal:8080/server/job/$triggerwhat/build?token=BUILD_ME
+          proposed=$(./version_lookup.py -r $rel -p Proposed -s Published $pkg)
+          updates=$(./version_lookup.py -r $rel -p Updates -s Published $pkg)
+          # output is <pkg>,<rel>,<pocket>,<state>,<version>
+          pver=$(echo "$proposed" | sed "s/.*,//")
+          uver=$(echo "$updates" | sed "s/.*,//")
+          if [ -z "$proposed" ]; then
+            echo "no $pkg in proposed"
+            exit 0
+          elif [ "$uver" = "$pver" ]; then
+            echo "$pkg in proposed == updates == $pver. no need to test."
+            exit 0
           fi
 
-
+          pre="cloud-init-integration-proposed-"
+          for t in $triggerwhat; do
+              curl -X POST --netrc-file $JENKINS_HOME/jenkins-bot-creds http://server-team-jenkins-be.internal:8080/server/job/$pre$t/build?token=BUILD_ME
+          done


### PR DESCRIPTION
There are times after a proposed package has migrated when it will
show up in -proposed and in -updates.  Our check was triggering
an integration test on -proposed when this was the case.