### PR TITLE
Replace use of bzr with git for curtin jobs

### DIFF
--- a/curtin/jobs-ci.yaml
+++ b/curtin/jobs-ci.yaml
@@ -76,7 +76,7 @@
             export no_proxy=launchpad.net
 
             rm -rf curtin-*
-            bzr branch ${{landing_candidate}} curtin-${{BUILD_NUMBER}}
+            git clone ${{landing_candidate}} curtin-${{BUILD_NUMBER}}
             cd curtin-${{BUILD_NUMBER}}
 
             tox

--- a/curtin/jobs-vmtest-daily.yaml
+++ b/curtin/jobs-vmtest-daily.yaml
@@ -62,7 +62,7 @@
           export CURTIN_VMTEST_CURTIN_EXE="curtin-from-container $LXC_NAME curtin"
 
           rm -Rf curtin-* output
-          bzr branch lp:curtin curtin-${{BUILD_NUMBER}}
+          git clone https://git.launchpad.net/curtin curtin-${{BUILD_NUMBER}}
           cd curtin-${{BUILD_NUMBER}}
           PATH="$PWD/tools:$PATH"
 

--- a/curtin/jobs-vmtest.yaml
+++ b/curtin/jobs-vmtest.yaml
@@ -27,7 +27,7 @@
             export https_proxy=http://squid.internal:3128
 
             rm -Rf curtin
-            bzr branch lp:curtin
+            git clone https://git.launchpad.net/curtin
             cd curtin
 
             ./tools/vmtest-sync-images
@@ -118,7 +118,7 @@
 
             rm -Rf curtin-*
             rm -Rf output
-            bzr branch ${branch} curtin-${BUILD_NUMBER}
+            git clone -b ${branch} https://git.launchpad.net/curtin curtin-${BUILD_NUMBER}
             cd curtin-${BUILD_NUMBER}
 
             ./tools/vmtest-system-setup

--- a/curtin/jobs.yaml
+++ b/curtin/jobs.yaml
@@ -25,7 +25,7 @@
           export no_proxy=launchpad.net
 
           rm -rf *
-          bzr branch lp:curtin build
+          git clone https://git.launchpad.net/curtin build
           cd build
 
           ./tools/build-deb -S -us -uc
@@ -56,7 +56,7 @@
           export no_proxy=launchpad.net
 
           rm -rf *
-          bzr branch ${{branch}} debug
+          git clone -b ${{branch}} https://git.launchpad.net/curtin debug
           cd debug
 
           tox ${{tox_parameters}}
@@ -77,7 +77,7 @@
           export no_proxy=launchpad.net
 
           rm -rf *
-          bzr branch lp:curtin style
+          git clone https://git.launchpad.net/curtin style
           cd style
 
           tox -e tip-pycodestyle
@@ -115,7 +115,7 @@
           export no_proxy=launchpad.net
 
           rm -rf *
-          bzr branch lp:curtin tests
+          git clone https://git.launchpad.net/curtin tests
           cd tests
 
           tox

--- a/curtin/parameters.yaml
+++ b/curtin/parameters.yaml
@@ -49,7 +49,7 @@
     parameters:
       - string:
           name: branch
-          default: lp:curtin
+          default: master
           description: LaunchPad branch to use for running the test.
 
 - parameter:


### PR DESCRIPTION
Use git over https for fetching curtin source code.