### PR TITLE
curtin vmtest: skip all skip-by-date when testing packages.

### DIFF
--- a/curtin/jobs-vmtest-daily.yaml
+++ b/curtin/jobs-vmtest-daily.yaml
@@ -63,6 +63,7 @@
           export apt_proxy=http://squid.internal:3128
           export TMPDIR=/var/lib/jenkins/tmp/
           export CURTIN_VMTEST_CURTIN_EXE="curtin-from-container $LXC_NAME curtin"
+          export CURTIN_VMTEST_SKIP_BY_DATE_BUGS="*"
 
           rm -Rf curtin-* output
           git clone --branch=master https://git.launchpad.net/curtin curtin-${{BUILD_NUMBER}}

--- a/curtin/jobs-vmtest-proposed.yaml
+++ b/curtin/jobs-vmtest-proposed.yaml
@@ -97,6 +97,7 @@
           export TMPDIR=/var/lib/jenkins/tmp/
           export CURTIN_VMTEST_CURTIN_EXE="curtin-from-container $LXC_NAME curtin"
           export CURTIN_VMTEST_TAR_DISKS=1
+          export CURTIN_VMTEST_SKIP_BY_DATE_BUGS="*"
 
           rm -Rf curtin-* output
           pull-lp-source curtin "$RELEASE"-proposed


### PR DESCRIPTION
Curtin vmtest skips some tests by date.  This mechanism allows us
to ignore (and not test) known issues, and be reminded of these
skips at a later date.  That works well for trunk.
There, when a failure pops up we can easily fix it.
When when we test packages, though, that is  more difficult.

The change here is to skip all 'skip-by-date' when running
tests of packages.