### PR TITLE
Add template for the new foundations_bugs metric.

### DIFF
--- a/metrics/default.yaml
+++ b/metrics/default.yaml
@@ -25,6 +25,7 @@
       - metric-foundations-proposed-migration
       - metric-foundations-autopkgtest-queue
       - metric-foundations-sru-queues
+      - metric-foundations-bugs
       - metric-foundations-uploads
       - metric-merges
       - metric-openstack-uploads

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -97,6 +97,13 @@
           metric_module: "cloud_image_sizes"
 
 - job-template:
+    name: metric-foundations-bugs
+    builders:
+      - metric-influxdb:
+          team: "foundations"
+          metric_module: "foundations_bugs"
+
+- job-template:
     name: metric-foundations-uploads
     builders:
         - builder-metric-uploads:

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -38,7 +38,7 @@
           cd metrics
           bzr branch lp:kpi-metrics-tools
           source kpi-metrics-tools/{team}-kpi-influxdb.txt
-          python3 -m metrics.{metric_module}
+          python3 -m metrics.{metric_module} {metric_arguments}
 
 - builder:
     name: builder-metric-uploads
@@ -101,7 +101,8 @@
     builders:
       - metric-influxdb:
           team: "foundations"
-          metric_module: "foundations_bugs"
+          metric_module: "team_bugs"
+          metric_arguments: "canonical-foundations"
 
 - job-template:
     name: metric-foundations-uploads

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -88,6 +88,7 @@
       - metric-influxdb:
           team: "foundations"
           metric_module: "docker_hub_images"
+          metric_arguments: ""
 
 - job-template:
     name: metric-foundations-cloud-image-sizes
@@ -95,6 +96,7 @@
       - metric-influxdb:
           team: "foundations"
           metric_module: "cloud_image_sizes"
+          metric_arguments: ""
 
 - job-template:
     name: metric-foundations-bugs
@@ -171,6 +173,7 @@
       - metric-influxdb:
           team: "server"
           metric_module: "iso"
+          metric_arguments: ""
 
 - job-template:
     name: metric-merges

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -103,7 +103,7 @@
     builders:
       - metric-influxdb:
           team: "foundations"
-          metric_module: "team_bugs"
+          metric_module: "team_assigned_bugs"
           metric_arguments: "canonical-foundations"
 
 - job-template:


### PR DESCRIPTION
Requires https://github.com/canonical-server/metrics/pull/41 to be reviewed and merged.