### PR TITLE
virt: Do not trigger chain if prep failed

### DIFF
--- a/virt/virt-amd64.yaml
+++ b/virt/virt-amd64.yaml
@@ -28,7 +28,6 @@
           recipients: josh.powers@canonical.com
       - trigger:
           project: virt-migrate-amd64-t
-          threshold: FAILURE
       - junit:
           results: result.xml
     builders:

--- a/virt/virt-ppc64el.yaml
+++ b/virt/virt-ppc64el.yaml
@@ -28,7 +28,6 @@
           recipients: josh.powers@canonical.com
       - trigger:
           project: virt-migrate-ppc64el-x
-          threshold: FAILURE
       - junit:
           results: result.xml
     builders:

--- a/virt/virt-s390x.yaml
+++ b/virt/virt-s390x.yaml
@@ -28,7 +28,6 @@
           recipients: josh.powers@canonical.com
       - trigger:
           project: virt-migrate-s390x-x
-          threshold: FAILURE
       - junit:
           results: result.xml
     builders:


### PR DESCRIPTION
As discussed, if prep fails anything following is random at best.